### PR TITLE
fix(routes): remove /api from root path and use the original one

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Available regions: Indonesia (`id`), Malaysia (`my`), Singapore (`sg`).
 
 | Route                | Method | Parameters             | Required | Examples               |
 | -------------------- | ------ | ---------------------- | -------- | ---------------------- |
-| `/register`          | POST   | `username`, `password` | Yes      | `johndoe`, `john123`   |
-| `/login`             | POST   | `username`, `password` | Yes      | `johndoe`, `john123`   |
+| `/auth/register`     | POST   | `username`, `password` | Yes      | `johndoe`, `john123`   |
+| `/auth/login`        | POST   | `username`, `password` | Yes      | `johndoe`, `john123`   |
 | `/:region`           | GET    | -                      | -        | `/id`                  |
 | `/:region`           | POST   | `...`                  | Yes      | `/id`                  |
 | `/:region`           | PATCH  | `...`                  | Yes      | `/id`                  |

--- a/__test__/app.test.ts
+++ b/__test__/app.test.ts
@@ -3,8 +3,8 @@ import { regions } from '../constants/regions';
 import request from 'supertest';
 import app from '../app';
 
-describe('GET /api', async () => {
-    const res = await request(app).get('/api');
+describe('GET /', async () => {
+    const res = await request(app).get('/');
     it('Should return 200 status code', () => {
         expect(res.statusCode).toBe(200);
         expect(res.type).toBe('application/json');
@@ -14,24 +14,24 @@ describe('GET /api', async () => {
     });
 });
 
-describe('GET /api/:region', () => {
+describe('GET /:region', () => {
     it('Should return 200 status code', () => {
         regions.forEach(async (region) => {
-            const res = await request(app).get(`/api/${region.code}`);
+            const res = await request(app).get(`/${region.code}`);
             expect(res.statusCode).toBe(200);
             expect(res.type).toBe('application/json');
         });
     });
     it('Should return an array', () => {
         regions.forEach(async (region) => {
-            const res = await request(app).get(`/api/${region.code}`);
+            const res = await request(app).get(`/${region.code}`);
             expect(res.body).toBeArray();
         });
     });
 });
 
-describe('GET /api/protected', async () => {
-    const res = await request(app).get('/api/protected');
+describe('GET /protected', async () => {
+    const res = await request(app).get('/protected');
     it('Should return 401 status code', () => {
         expect(res.statusCode).toBe(401);
         expect(res.unauthorized).toBeTrue();
@@ -39,36 +39,36 @@ describe('GET /api/protected', async () => {
     });
 });
 
-describe('POST /api/auth/register', async () => {
-    const res = await request(app).post('/api/auth/register');
+describe('POST /auth/register', async () => {
+    const res = await request(app).post('/auth/register');
     it('Should return 401 status code', () => {
         expect(res.statusCode).toBe(401);
         expect(res.unauthorized).toBeTrue();
     });
 });
 
-describe('POST /api/auth/login', async () => {
-    const res = await request(app).post('/api/auth/login');
+describe('POST /auth/login', async () => {
+    const res = await request(app).post('/auth/login');
     it('Should return 401 status code', () => {
         expect(res.statusCode).toBe(401);
         expect(res.unauthorized).toBeTrue();
     });
 });
 
-describe('POST /api/:region', () => {
+describe('POST /:region', () => {
     it('Should return 401 status code', () => {
         regions.forEach(async (region) => {
-            const res = await request(app).post(`/api/${region.code}`);
+            const res = await request(app).post(`/${region.code}`);
             expect(res.statusCode).toBe(401);
             expect(res.unauthorized).toBeTrue();
         });
     });
 });
 
-describe('PATCH /api/:region', () => {
+describe('PATCH /:region', () => {
     it('Should return 401 status code', () => {
         regions.forEach(async (region) => {
-            const res = await request(app).patch(`/api/${region.code}`);
+            const res = await request(app).patch(`/${region.code}`);
             expect(res.statusCode).toBe(401);
             expect(res.unauthorized).toBeTrue();
         });

--- a/app.ts
+++ b/app.ts
@@ -1,7 +1,6 @@
 import express from 'express';
 import morgan from 'morgan';
 import routes from './routes';
-import { root } from './routes/info/root';
 import { authErrorHandler } from './middleware/autherror';
 
 const app = express();
@@ -9,9 +8,7 @@ const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(morgan('short'));
-app.use('/api', routes);
-
-app.get('/', root);
+app.use('/', routes);
 app.use(authErrorHandler);
 
 export default app;

--- a/routes/index.ts
+++ b/routes/index.ts
@@ -4,22 +4,24 @@ import { authenticateJWT } from '../middleware/auth';
 import { Request } from 'express-jwt';
 import { Response } from 'express';
 import { useYTData } from '../functions/useYTData';
-import { apiRoute } from './info/api';
+import { root } from './info/root';
 import { registerRoute } from './auth/register';
 import { loginRoute } from './auth/login';
 import { protectedRoute } from './protected/test';
 import { regions } from '../constants/regions';
 import { changePassword } from './auth/changePassword';
 import { changeUsername } from './auth/changeUsername';
+import { notFound } from './info/notfound';
 
 const router: Router = express.Router();
 
-router.get('/', apiRoute);
+router.get('/', root);
 router.post('/auth/register', registerRoute);
 router.post('/auth/login', loginRoute);
 router.patch('/auth/change_password', changePassword);
 router.patch('/auth/change_username', changeUsername);
 router.get('/protected', protectedRoute);
+router.get('*', notFound);
 
 regions.forEach((region) => {
     // Public routes

--- a/routes/info/api.ts
+++ b/routes/info/api.ts
@@ -1,6 +1,0 @@
-import { Request, Response } from 'express';
-import { name, version } from '../../package.json';
-
-export const apiRoute = (req: Request, res: Response) => {
-    res.send({ _APPNAME: name, message: 'Hello!', version: version });
-};

--- a/routes/info/notfound.ts
+++ b/routes/info/notfound.ts
@@ -1,0 +1,5 @@
+import { Request, Response } from 'express';
+
+export const notFound = (req: Request, res: Response) => {
+    res.status(404).json({ message: 'Requested URL is not found!' });
+};

--- a/routes/info/root.ts
+++ b/routes/info/root.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
+import { name, version } from '../../package.json';
 
 export const root = (req: Request, res: Response) => {
-    res.send({ message: 'Hello, consider using /api as a root instead of this root path.' });
+    res.send({ _APPNAME: name, message: 'Hello!', version: version });
 };


### PR DESCRIPTION
This pull request has fixes by removing /api from root path and use the original root path instead.

> [!IMPORTANT]
> **This pull request is a breaking change. You may need to adapt with the new routes after this update.**